### PR TITLE
Handle exception when FB feed returns error code

### DIFF
--- a/src/SE344/Controllers/HomeController.cs
+++ b/src/SE344/Controllers/HomeController.cs
@@ -24,11 +24,11 @@ namespace SE344.Controllers
             _facebookApi.AccessToken = Context.User.FindFirstValue("access_token");
 
             var allIds = _stockHistory.getKnownIdentifiers();
-            var allStocks = await Task.WhenAll(allIds.Select(x => new Stock(x)).Select(_stockInfo.GetQuoteAsync));
+            var allStocks = Task.WhenAll(allIds.Select(x => new Stock(x)).Select(_stockInfo.GetQuoteAsync));
 
             var facebookFeedTask = _facebookApi.GetUserFeedAsync();
 
-            ViewData["Stocks"] = allStocks;
+            ViewData["Stocks"] = await allStocks;
             ViewData["Feed"] = await facebookFeedTask;
             return View();
         }

--- a/src/SE344/Services/Facebook/FacebookApiService.cs
+++ b/src/SE344/Services/Facebook/FacebookApiService.cs
@@ -26,8 +26,17 @@ namespace SE344.Services.Facebook
         /// <returns>A <see cref="JArray"/> of user's posts</returns>
         public async Task<JToken> GetUserFeedAsync()
         {
-            var query = new Dictionary<string, string> {{"fields", "from{name,id,link},message,created_time"}};
-            var res = await _client.GetStringAsync(BuildApiUrl("me/feed", query));
+            var query = new Dictionary<string, string> { { "fields", "from{name,id,link},message,created_time" } };
+
+            string res;
+            try
+            {
+                res = await _client.GetStringAsync(BuildApiUrl("me/feed", query));
+            }
+            catch (HttpRequestException)
+            {
+                return new JArray();
+            }
             return JObject.Parse(res)["data"];
         }
 
@@ -38,7 +47,7 @@ namespace SE344.Services.Facebook
         /// <returns>The ID of the newly created post if success</returns>
         public async Task<string> PostUserFeedAsync(string message)
         {
-            var postData = new Dictionary<string, string> {{"message", message}};
+            var postData = new Dictionary<string, string> { { "message", message } };
             var res = await _client.PostAsync(BuildApiUrl("me/feed"), new FormUrlEncodedContent(postData));
 
             if (res.IsSuccessStatusCode)


### PR DESCRIPTION
Silently handle error codes from Facebook, so now when you don't give permissions to the app it won't blow up.

Related issue #46.
